### PR TITLE
extend NIO storage driver

### DIFF
--- a/src/main/java/com/emc/mongoose/storage/driver/pravega/PravegaStorageDriver.java
+++ b/src/main/java/com/emc/mongoose/storage/driver/pravega/PravegaStorageDriver.java
@@ -1,7 +1,6 @@
 package com.emc.mongoose.storage.driver.pravega;
 
 import com.emc.mongoose.data.DataInput;
-import com.emc.mongoose.exception.InterruptRunException;
 import com.emc.mongoose.exception.OmgShootMyFootException;
 import com.emc.mongoose.item.DataItem;
 import com.emc.mongoose.item.Item;
@@ -14,7 +13,7 @@ import com.emc.mongoose.item.op.path.PathOperation;
 import com.emc.mongoose.logging.LogUtil;
 import com.emc.mongoose.logging.Loggers;
 import com.emc.mongoose.storage.Credential;
-import com.emc.mongoose.storage.driver.coop.CoopStorageDriverBase;
+import com.emc.mongoose.storage.driver.coop.nio.NioStorageDriverBase;
 import com.github.akurilov.commons.system.SizeInBytes;
 import com.github.akurilov.confuse.Config;
 import io.pravega.client.ClientFactory;
@@ -34,7 +33,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class PravegaStorageDriver<I extends Item, O extends Operation<I>>
-		extends CoopStorageDriverBase<I, O> {
+		extends NioStorageDriverBase<I, O> {
 
 	protected final String uriSchema;
 
@@ -144,65 +143,36 @@ public class PravegaStorageDriver<I extends Item, O extends Operation<I>>
 	}
 
 	@Override
-	protected boolean submit(O op) throws InterruptRunException, IllegalStateException {
+	protected final void invokeNio(final O operation) {
+		if(operation instanceof DataOperation) {
+			invokeFileNio((DataOperation<? extends DataItem>) operation);
+		} else if(operation instanceof PathOperation) {
+			invokeDirectoryNio((PathOperation<? extends PathItem>) operation);
+		} else {
+			throw new AssertionError("Not implemented");
+		}
+	}
+
+	private void invokeFileNio(DataOperation<? extends DataItem> fileOperation) {
+		final OpType opType = fileOperation.type();
+		final DataItem fileItem = fileOperation.item();
 		try {
-			if (op instanceof DataOperation) {
-				final DataOperation dataOp = (DataOperation) op;
-				final DataItem dataItem = dataOp.item();
-				switch (dataOp.type()) {
-					case NOOP:
-						// if(success) return true;
-						break;
-					case CREATE:
-						//TODO: EventStreamWriter<ByteBuffer>  ->  writeEvent
-						// if(success) return true;
-						break;
-					case READ:
-						//TODO: EventStreamReader<ByteBuffer>  ->  readNextEvent
-						// if(success) return true;
-						break;
-					default:
-						throw new AssertionError("Operation " + op.type() + " isn't supported");
-				}
-			} else if (op instanceof PathOperation) {
-				final PathOperation<? extends PathItem> pathOp = (PathOperation<? extends PathItem>) op;
-				final PathItem pathItem = pathOp.item();
-				switch (pathOp.type()) {
-					case NOOP:
-						// if(success) return true;
-						break;
-					case CREATE:
-						//TODO: StreamManager.createStream
-						// if(success) return true;
-						break;
-					case READ:
-						final String path = pathOp.dstPath();
-						final String scopeName = path.substring(0, path.indexOf("/"));
-						final String streamName = path.substring(path.indexOf("/") + 1);
-						if ((scopeMap.get(scopeName) == null) || (scopeMap.get(scopeName).get(streamName) == null)) {
-							//instead of this check there will be an http request, apparently.
-							Loggers.ERR.debug(
-									"Failed to delete the stream {} in the scope {}", streamName, scopeName);
-							pathOp.status(Operation.Status.RESP_FAIL_UNKNOWN);
-						}
-						if (invokePathRead(pathOp)) {
-							return true;
-						}
-						break;
-					case DELETE:
-						if(invokePathDelete((PathOperation<? extends PathItem>) op)) {
-							return true;
-						}
-						break;
-					default:
-						throw new AssertionError("Operation " + op.type() + "  isn't supported");
-				}
-			} else {
-				throw new AssertionError("Operation type " + op.type() + " isn't supported");
+			switch (opType) {
+				case NOOP:
+					//TODO
+					break;
+				case CREATE:
+					//TODO: EventStreamWriter<ByteBuffer>  ->  writeEvent
+					break;
+				case READ:
+					//TODO: EventStreamReader<ByteBuffer>  ->  readNextEvent
+					break;
+				default:
+					throw new AssertionError("Operation " + opType + " isn't supported");
 			}
+
 		} catch (final RuntimeException e) {
 			final Throwable cause = e.getCause();
-
 			if (cause instanceof IOException) {
 				LogUtil.exception(
 						Level.DEBUG, cause, "Failed IO"
@@ -213,24 +183,52 @@ public class PravegaStorageDriver<I extends Item, O extends Operation<I>>
 				LogUtil.exception(Level.DEBUG, e, "Unexpected failure");
 			}
 		}
-
-		return false;
 	}
 
-	@Override
-	protected int submit(List<O> ops, int from, int to) throws InterruptRunException, IllegalStateException {
-		int i = from;
-		for (; i < to; i++) {
-			if (!submit(ops.get(i))) break;
+	private void invokeDirectoryNio(PathOperation<? extends PathItem> pathOperation) {
+		final OpType opType = pathOperation.type();
+		final PathItem pathItem = pathOperation.item();
+		try {
+			switch (opType) {
+				case NOOP:
+					//TODO
+					break;
+				case CREATE:
+					//TODO: StreamManager.createStream
+					break;
+				case READ:
+					final String path = pathOperation.dstPath();
+					final String scopeName = path.substring(0, path.indexOf("/"));
+					final String streamName = path.substring(path.indexOf("/") + 1);
+					if ((scopeMap.get(scopeName) == null) || (scopeMap.get(scopeName).get(streamName) == null)) {
+						//instead of this check there will be an http request, apparently.
+						Loggers.ERR.debug(
+								"Failed to delete the stream {} in the scope {}", streamName, scopeName);
+						pathOperation.status(Operation.Status.RESP_FAIL_UNKNOWN);
+					}
+					if (invokePathRead(pathOperation)) {
+					}
+					break;
+				case DELETE:
+					if (invokePathDelete(pathOperation)) {
+					}
+					break;
+				default:
+					throw new AssertionError("Operation " + opType + "  isn't supported");
+			}
+		} catch (final RuntimeException e) {
+			final Throwable cause = e.getCause();
+			if (cause instanceof IOException) {
+				LogUtil.exception(
+						Level.DEBUG, cause, "Failed IO"
+				);
+			} else if (cause != null) {
+				LogUtil.exception(Level.DEBUG, cause, "Unexpected failure");
+			} else {
+				LogUtil.exception(Level.DEBUG, e, "Unexpected failure");
+			}
 		}
-		return i - from;
-	}
-
-	@Override
-	protected int submit(List<O> ops) throws InterruptRunException, IllegalStateException {
-		return submit(ops, 0, ops.size());
-	}
-
+    }
 
 	private boolean invokePathRead(final PathOperation<? extends PathItem> pathOp) {
 		//for now we consider that we use one StreamManager only


### PR DESCRIPTION
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.

Signed-off-by: Igor <hokletka@gmail.com>

Extend NIOStorageDriverBase instead of CoopStorageDriverBase. Change submit methods to invokeNio().