### PR TITLE
Add test stub for common tests and DataOperationTests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,8 @@ before_install:
 jobs:
   include:
 
-  - stage: "Integration Tests"
-    script: "./gradlew test --tests com.emc.mongoose.storage.driver.pravega.integration.*"
-
-  - stage: "System Tests"
-    script:
-    - "./gradlew clean jar"
-    - "./gradlew test --tests com.emc.mongoose.storage.driver.pravega.system.*"
+  - stage: "Tests"
+    script: "./gradlew test"
 
   - stage: "Deploy to DockerHub"
     script:

--- a/src/main/java/com/emc/mongoose/storage/driver/pravega/PravegaStorageDriver.java
+++ b/src/main/java/com/emc/mongoose/storage/driver/pravega/PravegaStorageDriver.java
@@ -47,7 +47,7 @@ public class PravegaStorageDriver<I extends Item, O extends Operation<I>>
 	protected int inBuffSize = BUFF_SIZE_MIN;
 	protected int outBuffSize = BUFF_SIZE_MAX;
 
-	private StreamManager streamManager;
+	//private StreamManager streamManager;
 	private Map<String, Map<String, Stream>> scopeMap = new HashMap<>();
 
 	public PravegaStorageDriver(
@@ -57,13 +57,13 @@ public class PravegaStorageDriver<I extends Item, O extends Operation<I>>
 			throws OmgShootMyFootException {
 		super(testStepId, dataInput, storageConfig, verifyFlag, batchSize);
 		this.uriSchema = uriSchema;
-		streamManager = StreamManager.create(URI.create(uriSchema));
+
 
 		final String uid = credential == null ? null : credential.getUid();
 		final Config nodeConfig = storageConfig.configVal("net-node");
 		nodePort = storageConfig.intVal("net-node-port");
 		final List<String> endpointAddrList = nodeConfig.listVal("addrs");
-		readerTimeoutMs = storageConfig.intVal("storage-item-input-readerTimeout");
+		readerTimeoutMs = storageConfig.intVal("item-input-readerTimeout");
 
 		endpointAddrs = endpointAddrList.toArray(new String[endpointAddrList.size()]);
 		requestAuthTokenFunc = null; // do not use
@@ -202,20 +202,13 @@ public class PravegaStorageDriver<I extends Item, O extends Operation<I>>
 					//TODO: StreamManager.createStream
 					break;
 				case READ:
-					final String path = pathOperation.dstPath();
-					final String scopeName = path.substring(0, path.indexOf("/"));
-					final String streamName = path.substring(path.indexOf("/") + 1);
-					if ((scopeMap.get(scopeName) == null) || (scopeMap.get(scopeName).get(streamName) == null)) {
-						//instead of this check there will be an http request, apparently.
-						Loggers.ERR.debug(
-								"Failed to delete the stream {} in the scope {}", streamName, scopeName);
-						pathOperation.status(Operation.Status.RESP_FAIL_UNKNOWN);
-					}
 					if (invokePathRead(pathOperation)) {
+						//finishOperation?
 					}
 					break;
 				case DELETE:
 					if (invokePathDelete(pathOperation)) {
+						//finishOperation?
 					}
 					break;
 				default:
@@ -280,8 +273,9 @@ public class PravegaStorageDriver<I extends Item, O extends Operation<I>>
 
 	protected boolean invokePathDelete(final PathOperation<? extends PathItem> pathOp) {
 		final String path = pathOp.dstPath();
+		StreamManager streamManager = StreamManager.create(URI.create(uriSchema));
 		final String scopeName = path.substring(0,path.indexOf("/"));
-		final String streamName = path.substring(path.indexOf("/")+1, path.length());
+		final String streamName = path.substring(path.indexOf("/")+1);
 		if(streamManager.sealStream(scopeName, streamName)){
 			if(streamManager.deleteStream(scopeName, streamName)) {
 				return true;

--- a/src/main/java/com/emc/mongoose/storage/driver/pravega/PravegaStorageDriver.java
+++ b/src/main/java/com/emc/mongoose/storage/driver/pravega/PravegaStorageDriver.java
@@ -273,7 +273,7 @@ public class PravegaStorageDriver<I extends Item, O extends Operation<I>>
 
 	protected boolean invokePathDelete(final PathOperation<? extends PathItem> pathOp) {
 		final String path = pathOp.dstPath();
-		StreamManager streamManager = StreamManager.create(URI.create(uriSchema));
+		final StreamManager streamManager = StreamManager.create(URI.create(uriSchema));
 		final String scopeName = path.substring(0,path.indexOf("/"));
 		final String streamName = path.substring(path.indexOf("/")+1);
 		if(streamManager.sealStream(scopeName, streamName)){

--- a/src/test/java/com/emc/mongoose/storage/driver/pravega/integration/CommonTest.java
+++ b/src/test/java/com/emc/mongoose/storage/driver/pravega/integration/CommonTest.java
@@ -119,12 +119,12 @@ public class CommonTest
 			}
 		}
 
-	public CommonTest ()
+		public CommonTest ()
 			throws OmgShootMyFootException {
 			this(getConfig());
 		}
 
-	private CommonTest (final Config config)
+		private CommonTest (final Config config)
 			throws OmgShootMyFootException {
 			super(
 					"tcp://127.0.0.1:9090", "test-data-pravega-driver", DATA_INPUT,
@@ -148,7 +148,6 @@ public class CommonTest
 			PRAVEGA_NODE_CONTAINER.close();
 
 		}
-
 
 
 		@Test

--- a/src/test/java/com/emc/mongoose/storage/driver/pravega/integration/CommonTest.java
+++ b/src/test/java/com/emc/mongoose/storage/driver/pravega/integration/CommonTest.java
@@ -1,0 +1,158 @@
+package com.emc.mongoose.storage.driver.pravega.integration;
+
+import com.emc.mongoose.data.DataInput;
+import com.emc.mongoose.env.Extension;
+import com.emc.mongoose.exception.OmgShootMyFootException;
+import com.emc.mongoose.item.DataItem;
+import com.emc.mongoose.item.DataItemImpl;
+import com.emc.mongoose.item.op.OpType;
+import com.emc.mongoose.item.op.Operation;
+import com.emc.mongoose.item.op.data.DataOperation;
+import com.emc.mongoose.item.op.data.DataOperationImpl;
+import com.emc.mongoose.storage.Credential;
+
+import com.emc.mongoose.storage.driver.pravega.PravegaStorageDriver;
+import com.emc.mongoose.storage.driver.pravega.util.docker.PravegaNodeContainer;
+import com.github.akurilov.commons.collection.Range;
+import com.github.akurilov.commons.collection.TreeUtil;
+import com.github.akurilov.commons.system.SizeInBytes;
+import com.github.akurilov.confuse.Config;
+import com.github.akurilov.confuse.SchemaProvider;
+import com.github.akurilov.confuse.impl.BasicConfig;
+
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.emc.mongoose.Constants.APP_NAME;
+import static com.emc.mongoose.Constants.MIB;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class CommonTest
+		extends PravegaStorageDriver<DataItem, DataOperation<DataItem>> {
+
+		private static final DataInput DATA_INPUT;
+		static {
+			try {
+				DATA_INPUT = DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("4MB"), 16);
+			} catch(final IOException e) {
+				throw new AssertionError(e);
+			}
+		}
+
+		private static final Credential CREDENTIAL = Credential.getInstance("root", "nope");
+		private static PravegaNodeContainer PRAVEGA_NODE_CONTAINER;
+
+		private static Config getConfig() {
+			try {
+				final List<Map<String, Object>> configSchemas = Extension
+						.load(Thread.currentThread().getContextClassLoader())
+						.stream()
+						.map(Extension::schemaProvider)
+						.filter(Objects::nonNull)
+						.map(
+								schemaProvider -> {
+									try {
+										return schemaProvider.schema();
+									} catch(final Exception e) {
+										fail(e.getMessage());
+									}
+									return null;
+								}
+						)
+						.filter(Objects::nonNull)
+						.collect(Collectors.toList());
+				SchemaProvider
+						.resolve(APP_NAME, Thread.currentThread().getContextClassLoader())
+						.stream()
+						.findFirst()
+						.ifPresent(configSchemas::add);
+				final Map<String, Object> configSchema = TreeUtil.reduceForest(configSchemas);
+				final Config config = new BasicConfig("-", configSchema);
+
+
+				config.val("load-batch-size", 4096);
+
+				config.val("storage-net-reuseAddr", true);
+				config.val("storage-net-bindBacklogSize", 0);
+				config.val("storage-net-keepAlive", true);
+				config.val("storage-net-rcvBuf", 0);
+				config.val("storage-net-sndBuf", 0);
+				config.val("storage-net-ssl", false);
+				config.val("storage-net-tcpNoDelay", false);
+				config.val("storage-net-interestOpQueued", false);
+				config.val("storage-net-linger", 0);
+				config.val("storage-net-timeoutMilliSec", 0);
+				config.val("storage-net-node-addrs", Collections.singletonList("127.0.0.1"));
+				config.val("storage-net-node-port", PravegaNodeContainer.PORT);
+				config.val("storage-net-node-connAttemptsLimit", 0);
+
+				config.val("storage-item-input-readerTimeout", 100);
+
+				config.val("storage-auth-uid", CREDENTIAL.getUid());
+				config.val("storage-auth-token", null);
+				config.val("storage-auth-secret", CREDENTIAL.getSecret());
+
+
+				config.val("storage-driver-threads", 0);
+				config.val("storage-driver-limit-queue-input", 1_000_000);
+				config.val("storage-driver-limit-queue-output", 1_000_000);
+				config.val("storage-driver-limit-concurrency", 0);
+				return config;
+			} catch(final Throwable cause) {
+				throw new RuntimeException(cause);
+			}
+		}
+
+	public CommonTest ()
+			throws OmgShootMyFootException {
+			this(getConfig());
+		}
+
+	private CommonTest (final Config config)
+			throws OmgShootMyFootException {
+			super(
+					"tcp://127.0.0.1:9090", "test-data-pravega-driver", DATA_INPUT,
+					config.configVal("storage"), true, config.configVal("load").intVal("batch-size")
+			);
+		}
+
+		@BeforeClass
+		public static void setUpClass()
+			throws Exception {
+			try {
+				PRAVEGA_NODE_CONTAINER = new PravegaNodeContainer();
+			} catch(final Exception e) {
+				throw new AssertionError(e);
+			}
+		}
+
+		@AfterClass
+		public static void tearDownClass()
+			throws Exception {
+			PRAVEGA_NODE_CONTAINER.close();
+
+		}
+
+
+
+		@Test
+		public final void testExample()
+			throws Exception {
+		}
+}

--- a/src/test/java/com/emc/mongoose/storage/driver/pravega/integration/DataOperationsTest.java
+++ b/src/test/java/com/emc/mongoose/storage/driver/pravega/integration/DataOperationsTest.java
@@ -1,0 +1,201 @@
+package com.emc.mongoose.storage.driver.pravega.integration;
+
+import com.emc.mongoose.data.DataInput;
+import com.emc.mongoose.env.Extension;
+import com.emc.mongoose.exception.OmgShootMyFootException;
+import com.emc.mongoose.item.DataItem;
+import com.emc.mongoose.item.DataItemImpl;
+import com.emc.mongoose.item.op.OpType;
+import com.emc.mongoose.item.op.Operation;
+import com.emc.mongoose.item.op.data.DataOperation;
+import com.emc.mongoose.item.op.data.DataOperationImpl;
+import com.emc.mongoose.storage.Credential;
+
+import com.emc.mongoose.storage.driver.pravega.PravegaStorageDriver;
+import com.emc.mongoose.storage.driver.pravega.util.docker.PravegaNodeContainer;
+import com.github.akurilov.commons.collection.Range;
+import com.github.akurilov.commons.collection.TreeUtil;
+import com.github.akurilov.commons.system.SizeInBytes;
+import com.github.akurilov.confuse.Config;
+import com.github.akurilov.confuse.SchemaProvider;
+import com.github.akurilov.confuse.impl.BasicConfig;
+
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.emc.mongoose.Constants.APP_NAME;
+import static com.emc.mongoose.Constants.MIB;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class DataOperationsTest
+		extends PravegaStorageDriver<DataItem, DataOperation<DataItem>> {
+
+	private static final DataInput DATA_INPUT;
+	static {
+		try {
+			DATA_INPUT = DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("4MB"), 16);
+		} catch(final IOException e) {
+			throw new AssertionError(e);
+		}
+	}
+
+	private static final Credential CREDENTIAL = Credential.getInstance("root", "nope");
+	private static PravegaNodeContainer PRAVEGA_NODE_CONTAINER;
+
+	private static Config getConfig() {
+		try {
+			final List<Map<String, Object>> configSchemas = Extension
+					.load(Thread.currentThread().getContextClassLoader())
+					.stream()
+					.map(Extension::schemaProvider)
+					.filter(Objects::nonNull)
+					.map(
+							schemaProvider -> {
+								try {
+									return schemaProvider.schema();
+								} catch(final Exception e) {
+									fail(e.getMessage());
+								}
+								return null;
+							}
+					)
+					.filter(Objects::nonNull)
+					.collect(Collectors.toList());
+			SchemaProvider
+					.resolve(APP_NAME, Thread.currentThread().getContextClassLoader())
+					.stream()
+					.findFirst()
+					.ifPresent(configSchemas::add);
+			final Map<String, Object> configSchema = TreeUtil.reduceForest(configSchemas);
+			final Config config = new BasicConfig("-", configSchema);
+
+			config.val("load-batch-size", 4096);
+
+			config.val("storage-net-reuseAddr", true);
+			config.val("storage-net-bindBacklogSize", 0);
+			config.val("storage-net-keepAlive", true);
+			config.val("storage-net-rcvBuf", 0);
+			config.val("storage-net-sndBuf", 0);
+			config.val("storage-net-ssl", false);
+			config.val("storage-net-tcpNoDelay", false);
+			config.val("storage-net-interestOpQueued", false);
+			config.val("storage-net-linger", 0);
+			config.val("storage-net-timeoutMilliSec", 0);
+			config.val("storage-net-node-addrs", Collections.singletonList("127.0.0.1"));
+			config.val("storage-net-node-port", PravegaNodeContainer.PORT);
+			config.val("storage-net-node-connAttemptsLimit", 0);
+
+			config.val("storage-item-input-readerTimeout", 100);
+
+			config.val("storage-auth-uid", CREDENTIAL.getUid());
+			config.val("storage-auth-token", null);
+			config.val("storage-auth-secret", CREDENTIAL.getSecret());
+
+
+			config.val("storage-driver-threads", 0);
+			config.val("storage-driver-limit-queue-input", 1_000_000);
+			config.val("storage-driver-limit-queue-output", 1_000_000);
+			config.val("storage-driver-limit-concurrency", 0);
+			return config;
+		} catch(final Throwable cause) {
+			throw new RuntimeException(cause);
+		}
+	}
+
+	public DataOperationsTest()
+			throws OmgShootMyFootException {
+		this(getConfig());
+	}
+
+	private DataOperationsTest(final Config config)
+			throws OmgShootMyFootException {
+		super(
+				"tcp://127.0.0.1:9090", "test-data-pravega-driver", DATA_INPUT,
+				config.configVal("storage"), true, config.configVal("load").intVal("batch-size")
+		);
+	}
+
+	@BeforeClass
+	public static void setUpClass()
+			throws Exception {
+		try {
+			PRAVEGA_NODE_CONTAINER = new PravegaNodeContainer();
+		} catch(final Exception e) {
+			throw new AssertionError(e);
+		}
+	}
+
+	@AfterClass
+	public static void tearDownClass()
+			throws Exception {
+		PRAVEGA_NODE_CONTAINER.close();
+
+	}
+
+
+
+	@Test
+	public final void testCreateFile()
+			throws Exception {
+	}
+
+	@Test
+	public final void testCopyFile()
+			throws Exception {
+	}
+
+	@Test @Ignore
+	public final void testConcatFile()
+			throws Exception {
+
+}
+
+	@Test
+	public final void testReadFullFile()
+			throws Exception {
+	}
+
+	@Test
+	public final void testReadFixedRangesFile()
+			throws Exception {
+
+	}
+
+	@Test
+	public final void testReadRandomRangesFile()
+			throws Exception {
+	}
+
+	@Test
+	public final void testOverwriteFile()
+			throws Exception {
+
+}
+
+	@Test
+	public final void testAppendFile()
+			throws Exception {
+	}
+
+	@Test
+	public final void testDeleteFile()
+			throws Exception {
+
+		}
+}

--- a/src/test/java/com/emc/mongoose/storage/driver/pravega/integration/DataOperationsTest.java
+++ b/src/test/java/com/emc/mongoose/storage/driver/pravega/integration/DataOperationsTest.java
@@ -47,10 +47,11 @@ public class DataOperationsTest
 		extends PravegaStorageDriver<DataItem, DataOperation<DataItem>> {
 
 	private static final DataInput DATA_INPUT;
+
 	static {
 		try {
 			DATA_INPUT = DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("4MB"), 16);
-		} catch(final IOException e) {
+		} catch (final IOException e) {
 			throw new AssertionError(e);
 		}
 	}
@@ -69,7 +70,7 @@ public class DataOperationsTest
 							schemaProvider -> {
 								try {
 									return schemaProvider.schema();
-								} catch(final Exception e) {
+								} catch (final Exception e) {
 									fail(e.getMessage());
 								}
 								return null;
@@ -113,7 +114,7 @@ public class DataOperationsTest
 			config.val("storage-driver-limit-queue-output", 1_000_000);
 			config.val("storage-driver-limit-concurrency", 0);
 			return config;
-		} catch(final Throwable cause) {
+		} catch (final Throwable cause) {
 			throw new RuntimeException(cause);
 		}
 	}
@@ -136,7 +137,7 @@ public class DataOperationsTest
 			throws Exception {
 		try {
 			PRAVEGA_NODE_CONTAINER = new PravegaNodeContainer();
-		} catch(final Exception e) {
+		} catch (final Exception e) {
 			throw new AssertionError(e);
 		}
 	}
@@ -145,9 +146,7 @@ public class DataOperationsTest
 	public static void tearDownClass()
 			throws Exception {
 		PRAVEGA_NODE_CONTAINER.close();
-
 	}
-
 
 
 	@Test
@@ -160,11 +159,11 @@ public class DataOperationsTest
 			throws Exception {
 	}
 
-	@Test @Ignore
+	@Test
+	@Ignore
 	public final void testConcatFile()
 			throws Exception {
-
-}
+	}
 
 	@Test
 	public final void testReadFullFile()
@@ -174,7 +173,6 @@ public class DataOperationsTest
 	@Test
 	public final void testReadFixedRangesFile()
 			throws Exception {
-
 	}
 
 	@Test
@@ -185,8 +183,7 @@ public class DataOperationsTest
 	@Test
 	public final void testOverwriteFile()
 			throws Exception {
-
-}
+	}
 
 	@Test
 	public final void testAppendFile()
@@ -196,6 +193,5 @@ public class DataOperationsTest
 	@Test
 	public final void testDeleteFile()
 			throws Exception {
-
-		}
+	}
 }

--- a/src/test/java/com/emc/mongoose/storage/driver/pravega/util/docker/PravegaNodeContainer.java
+++ b/src/test/java/com/emc/mongoose/storage/driver/pravega/util/docker/PravegaNodeContainer.java
@@ -14,12 +14,12 @@ import java.util.logging.Logger;
 public class PravegaNodeContainer
 		implements Closeable {
 
-		public static final int PORT = 9090;
-		private static final Logger LOG = Logger.getLogger(PravegaNodeContainer.class.getSimpleName());
-		private static final String IMAGE_NAME = "pravega/pravega:latest";
-		private static final DockerClient DOCKER_CLIENT = DockerClientBuilder.getInstance().build();
+	public static final int PORT = 9090;
+	private static final Logger LOG = Logger.getLogger(PravegaNodeContainer.class.getSimpleName());
+	private static final String IMAGE_NAME = "pravega/pravega:latest";
+	private static final DockerClient DOCKER_CLIENT = DockerClientBuilder.getInstance().build();
 
-		private static String CONTAINER_ID = null;
+	private static String CONTAINER_ID = null;
 
 	public PravegaNodeContainer()
 			throws Exception {
@@ -48,7 +48,7 @@ public class PravegaNodeContainer
 
 	}
 
-		public final void close () {
+	public final void close() {
 		if (CONTAINER_ID != null) {
 			LOG.info("docker kill " + CONTAINER_ID + "...");
 			DOCKER_CLIENT.killContainerCmd(CONTAINER_ID).exec();
@@ -57,4 +57,4 @@ public class PravegaNodeContainer
 			CONTAINER_ID = null;
 		}
 	}
-	}
+}

--- a/src/test/java/com/emc/mongoose/storage/driver/pravega/util/docker/PravegaNodeContainer.java
+++ b/src/test/java/com/emc/mongoose/storage/driver/pravega/util/docker/PravegaNodeContainer.java
@@ -1,0 +1,60 @@
+package com.emc.mongoose.storage.driver.pravega.util.docker;
+
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.CreateContainerResponse;
+import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.core.DockerClientBuilder;
+import com.github.dockerjava.core.command.PullImageResultCallback;
+
+import java.io.Closeable;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+public class PravegaNodeContainer
+		implements Closeable {
+
+		public static final int PORT = 9090;
+		private static final Logger LOG = Logger.getLogger(PravegaNodeContainer.class.getSimpleName());
+		private static final String IMAGE_NAME = "pravega/pravega:latest";
+		private static final DockerClient DOCKER_CLIENT = DockerClientBuilder.getInstance().build();
+
+		private static String CONTAINER_ID = null;
+
+	public PravegaNodeContainer()
+			throws Exception {
+		try {
+			DOCKER_CLIENT.inspectImageCmd(IMAGE_NAME).exec();
+		} catch (final NotFoundException e) {
+			DOCKER_CLIENT
+					.pullImageCmd(IMAGE_NAME)
+					.exec(new PullImageResultCallback())
+					.awaitCompletion();
+		}
+
+		final CreateContainerResponse container = DOCKER_CLIENT
+				.createContainerCmd(IMAGE_NAME)
+				.withCmd("standalone")
+				.withName("pravega_node")
+				.withNetworkMode("host")
+
+				.withAttachStderr(true)
+				.withAttachStdout(true)
+				.exec();
+		CONTAINER_ID = container.getId();
+		LOG.info("docker start " + CONTAINER_ID + "...");
+		DOCKER_CLIENT.startContainerCmd(CONTAINER_ID).exec();
+		TimeUnit.SECONDS.sleep(30);
+
+	}
+
+		public final void close () {
+		if (CONTAINER_ID != null) {
+			LOG.info("docker kill " + CONTAINER_ID + "...");
+			DOCKER_CLIENT.killContainerCmd(CONTAINER_ID).exec();
+			LOG.info("docker rm " + CONTAINER_ID + "...");
+			DOCKER_CLIENT.removeContainerCmd(CONTAINER_ID).exec();
+			CONTAINER_ID = null;
+		}
+	}
+	}


### PR DESCRIPTION
Add stub where we create a pravega standalone container and then we run some empty tests. After creation of the container we call a constructor
of pravega storage driver.
After that the pravega docker container is killed.

Besides, the map check in invokePathRead was deleted as useless. StreamManager was deleted from class fields, as it is unavailable to use it this way (on Pravega level).