### PR TITLE
Change inheritance to composition for common tests and DataOperationTests

### DIFF
--- a/src/test/java/com/emc/mongoose/storage/driver/pravega/integration/CommonTest.java
+++ b/src/test/java/com/emc/mongoose/storage/driver/pravega/integration/CommonTest.java
@@ -43,9 +43,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class CommonTest
-		extends PravegaStorageDriver<DataItem, DataOperation<DataItem>> {
-
+public class CommonTest {
+		private final PravegaStorageDriver pravegaStorageDriver;
 		private static final DataInput DATA_INPUT;
 		static {
 			try {
@@ -126,7 +125,7 @@ public class CommonTest
 
 		private CommonTest (final Config config)
 			throws OmgShootMyFootException {
-			super(
+			pravegaStorageDriver = new PravegaStorageDriver(
 					"tcp://127.0.0.1:9090", "test-data-pravega-driver", DATA_INPUT,
 					config.configVal("storage"), true, config.configVal("load").intVal("batch-size")
 			);

--- a/src/test/java/com/emc/mongoose/storage/driver/pravega/integration/DataOperationsTest.java
+++ b/src/test/java/com/emc/mongoose/storage/driver/pravega/integration/DataOperationsTest.java
@@ -43,9 +43,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class DataOperationsTest
-		extends PravegaStorageDriver<DataItem, DataOperation<DataItem>> {
-
+public class DataOperationsTest {
+	private final PravegaStorageDriver pravegaStorageDriver;
 	private static final DataInput DATA_INPUT;
 
 	static {
@@ -126,7 +125,8 @@ public class DataOperationsTest
 
 	private DataOperationsTest(final Config config)
 			throws OmgShootMyFootException {
-		super(
+
+		pravegaStorageDriver = new PravegaStorageDriver<DataItem, DataOperation<DataItem>>(
 				"tcp://127.0.0.1:9090", "test-data-pravega-driver", DATA_INPUT,
 				config.configVal("storage"), true, config.configVal("load").intVal("batch-size")
 		);


### PR DESCRIPTION
By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.

Change inheritance from Pravega storage driver to composition.

Signed-off-by: Alexander <alex15051997@yandex.com>