### PR TITLE
Stream delete adoption

### DIFF
--- a/src/main/java/com/emc/mongoose/storage/driver/pravega/PravegaStorageDriver.java
+++ b/src/main/java/com/emc/mongoose/storage/driver/pravega/PravegaStorageDriver.java
@@ -471,7 +471,7 @@ extends CoopStorageDriverBase<I, O>  {
 	void submitStreamDeleteOperation(final PathOperation streamOp, final String nodeAddr) {
 		try {
 			final String scopeName = DEFAULT_SCOPE; // TODO make this configurable
-			final String streamName = streamOp.dstPath();
+			final String streamName = streamOp.item().name();
 			final URI endpointUri = endpointCache.computeIfAbsent(nodeAddr, this::makeEndpointUri);
 			final StreamManager streamMgr = streamMgrCache.computeIfAbsent(endpointUri, StreamManager::create);
 			if (streamMgr.sealStream(scopeName, streamName)) {

--- a/src/main/java/com/emc/mongoose/storage/driver/pravega/PravegaStorageDriver.java
+++ b/src/main/java/com/emc/mongoose/storage/driver/pravega/PravegaStorageDriver.java
@@ -5,6 +5,7 @@ import static com.emc.mongoose.item.op.Operation.Status.FAIL_UNKNOWN;
 import static com.emc.mongoose.item.op.Operation.Status.INTERRUPTED;
 import static com.emc.mongoose.item.op.Operation.Status.RESP_FAIL_CLIENT;
 import static com.emc.mongoose.item.op.Operation.Status.SUCC;
+import static com.emc.mongoose.item.op.Operation.Status.RESP_FAIL_UNKNOWN;
 import static com.emc.mongoose.storage.driver.pravega.PravegaConstants.DEFAULT_SCOPE;
 import static com.emc.mongoose.storage.driver.pravega.PravegaConstants.DEFAULT_URI_SCHEMA;
 import static com.emc.mongoose.storage.driver.pravega.PravegaConstants.DRIVER_NAME;
@@ -468,7 +469,35 @@ extends CoopStorageDriverBase<I, O>  {
 	}
 
 	void submitStreamDeleteOperation(final PathOperation streamOp, final String nodeAddr) {
-		// TODO: Igor, issue SDP-49
+		try {
+			final String scopeName = DEFAULT_SCOPE; // TODO make this configurable
+			final String streamName = streamOp.dstPath();
+			final URI endpointUri = endpointCache.computeIfAbsent(nodeAddr, this::makeEndpointUri);
+			final StreamManager streamMgr = streamMgrCache.computeIfAbsent(endpointUri, StreamManager::create);
+			if (streamMgr.sealStream(scopeName, streamName)) {
+				if(streamMgr.deleteStream(scopeName, streamName)) {
+					completeOperation((O) streamOp, SUCC);
+				} else {
+					Loggers.ERR.debug(
+							"Failed to delete the stream {} in the scope {}", streamName,
+							scopeName);
+					completeOperation((O) streamOp, RESP_FAIL_UNKNOWN);
+				}
+			} else {
+				Loggers.ERR.debug(
+						"Failed to seal the stream {} in the scope {}", streamName,
+						scopeName);
+				completeOperation((O) streamOp, RESP_FAIL_UNKNOWN);
+			}
+		} catch(final NullPointerException e) {
+			if(!isStarted()) {
+				completeOperation((O) streamOp, INTERRUPTED);
+			} else {
+				completeFailedOperation((O) streamOp, e);
+			}
+		} catch(final Throwable cause) {
+			completeFailedOperation((O) streamOp, cause);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.

Signed-off-by: Igor <hokletka@gmail.com>

  Adopt streamDelete method for new refactored design. It doesn't parse dstPath() to get stream and scope name anymore.
 Also it uses complete operation methods to set the status of delete operation.