### PR TITLE
Make stream create/delete operation asynchronous

### DIFF
--- a/src/main/java/com/emc/mongoose/storage/driver/pravega/PravegaStorageDriver.java
+++ b/src/main/java/com/emc/mongoose/storage/driver/pravega/PravegaStorageDriver.java
@@ -554,8 +554,10 @@ extends CoopStorageDriverBase<I, O>  {
 		}
 	}
 
-	boolean completeStreamCreateOperation(final PathOperation streamOp, final boolean result, final Throwable thrown,
-	final String scopeName, final String streamName) { // TODO erase code duplication
+	boolean completeStreamCreateOperation(final PathOperation streamOp, final boolean result, final Throwable thrown) {
+		// TODO erase code duplication
+		val scopeName = DEFAULT_SCOPE;
+		val streamName = extractStreamName(streamOp.item().name());
 		if(null == thrown) {
 			if(result){
 				return completeOperation((O) streamOp, SUCC);
@@ -585,7 +587,7 @@ extends CoopStorageDriverBase<I, O>  {
 			 */
 			val createStreamFuture = controller.createStream(combineStreamConfigAndName(streamName, streamConfig));
 			createStreamFuture.handle((returned, thrown) ->
-				completeStreamCreateOperation(streamOp,returned,thrown,scopeName,streamName)
+				completeStreamCreateOperation(streamOp,returned,thrown)
 			);
 		} catch(final NullPointerException e) {
 			if(!isStarted()) {
@@ -605,8 +607,10 @@ extends CoopStorageDriverBase<I, O>  {
 		// TODO: Alex, issue SDP-51
 	}
 
-	boolean completeStreamDeleteOperation(final PathOperation streamOp, final boolean result, final Throwable thrown,
-	final String scopeName, final String streamName) { // TODO erase code duplication
+	boolean completeStreamDeleteOperation(final PathOperation streamOp, final boolean result, final Throwable thrown) {
+		// TODO erase code duplication
+		val scopeName = DEFAULT_SCOPE;
+		val streamName = extractStreamName(streamOp.item().name());
 		if(null == thrown) {
 			if(result){
 				return completeOperation((O) streamOp, SUCC);
@@ -635,7 +639,7 @@ extends CoopStorageDriverBase<I, O>  {
 			}
 			val deleteStreamFuture = controller.deleteStream(scopeName,streamName);
 			deleteStreamFuture.handle((returned, thrown) ->
-					completeStreamDeleteOperation(streamOp, returned, thrown, scopeName, streamName)
+					completeStreamDeleteOperation(streamOp, returned, thrown)
 			);
 		} catch(final NullPointerException e) {
 			if(!isStarted()) {

--- a/src/main/java/com/emc/mongoose/storage/driver/pravega/PravegaStorageDriver.java
+++ b/src/main/java/com/emc/mongoose/storage/driver/pravega/PravegaStorageDriver.java
@@ -554,6 +554,23 @@ extends CoopStorageDriverBase<I, O>  {
 		}
 	}
 
+	boolean completeStreamCreateOperation(final PathOperation streamOp, final boolean result, final Throwable thrown,
+	final String scopeName, final String streamName) { // TODO erase code duplication
+		if(null == thrown) {
+			if(result){
+				return completeOperation((O) streamOp, SUCC);
+			} else {
+				//Should I give stream and scope name to this method?
+				Loggers.ERR.debug(
+						"The stream {} already exists in the scope {}", streamName, scopeName
+				);
+				return completeOperation((O) streamOp, RESP_FAIL_UNKNOWN);
+			}
+		} else {
+			return completeFailedOperation((O) streamOp, thrown);
+		}
+	}
+
 	void submitStreamCreateOperation(final PathOperation streamOp, final String nodeAddr) {
 		try {
 			val endpointUri = endpointCache.computeIfAbsent(nodeAddr, this::createEndpointUri);
@@ -566,24 +583,16 @@ extends CoopStorageDriverBase<I, O>  {
 			/*We need to use StreamConfiguration.builder() because scopeCreateFuncForStreamConfig returns
 			StreamConfig without streamName field. So this looks like implementation of StreamManager.createStream()
 			 */
-			if(controller.createStream(combineStreamConfigAndName(streamName, streamConfig))
-			.get(controlApiTimeoutMillis, TimeUnit.MILLISECONDS)) {
-				completeOperation((O) streamOp, SUCC);
-			} else {
-				Loggers.ERR.debug(
-					"The stream {} already exists in the scope {}", streamName, scopeName
-				);
-				completeOperation((O) streamOp, RESP_FAIL_UNKNOWN);
-			}
+			val createStreamFuture = controller.createStream(combineStreamConfigAndName(streamName, streamConfig));
+			createStreamFuture.handle((returned, thrown) ->
+				completeStreamCreateOperation(streamOp,returned,thrown,scopeName,streamName)
+			);
 		} catch(final NullPointerException e) {
 			if(!isStarted()) {
 				completeOperation((O) streamOp, INTERRUPTED);
 			} else {
 				completeFailedOperation((O) streamOp, e);
 			}
-		} catch(final InterruptedException e) {
-			completeOperation((O) streamOp, INTERRUPTED);
-			throw new InterruptRunException(e);
 		} catch(final InterruptRunException e) {
 			completeOperation((O) streamOp, INTERRUPTED);
 			throw e;
@@ -596,31 +605,38 @@ extends CoopStorageDriverBase<I, O>  {
 		// TODO: Alex, issue SDP-51
 	}
 
+	boolean completeStreamDeleteOperation(final PathOperation streamOp, final boolean result, final Throwable thrown,
+	final String scopeName, final String streamName) { // TODO erase code duplication
+		if(null == thrown) {
+			if(result){
+				return completeOperation((O) streamOp, SUCC);
+			} else {
+				//Should I give stream and scope name to this method?
+				Loggers.ERR.debug(
+					"Failed to delete the stream {} in the scope {}", streamName, scopeName
+				);
+				return completeOperation((O) streamOp, RESP_FAIL_UNKNOWN);
+			}
+		} else {
+			return completeFailedOperation((O) streamOp, thrown);
+		}
+	}
+
 	void submitStreamDeleteOperation(final PathOperation streamOp, final String nodeAddr) {
 		try {
-			final String scopeName = DEFAULT_SCOPE; // TODO make this configurable
-			final String streamName = streamOp.item().name();
-			final URI endpointUri = endpointCache.computeIfAbsent(nodeAddr, this::createEndpointUri);
-			final Controller controller = controllerCache.computeIfAbsent(endpointUri, this::createController);
-			if(controller.sealStream(scopeName, streamName).get(controlApiTimeoutMillis, TimeUnit.MILLISECONDS)) {
-				if(
-					controller
-						.deleteStream(scopeName, streamName)
-						.get(controlApiTimeoutMillis, TimeUnit.MILLISECONDS)
-				) {
-					completeOperation((O) streamOp, SUCC);
-				} else {
-					Loggers.ERR.debug(
-							"Failed to delete the stream {} in the scope {}", streamName,
-							scopeName);
-					completeOperation((O) streamOp, RESP_FAIL_UNKNOWN);
-				}
-			} else {
+			val scopeName = DEFAULT_SCOPE; // TODO make this configurable
+			val streamName = extractStreamName(streamOp.item().name());
+			val endpointUri = endpointCache.computeIfAbsent(nodeAddr, this::createEndpointUri);
+			val controller = controllerCache.computeIfAbsent(endpointUri, this::createController);
+			if(!controller.sealStream(scopeName, streamName).get(controlApiTimeoutMillis, TimeUnit.MILLISECONDS)) {
 				Loggers.ERR.debug(
-						"Failed to seal the stream {} in the scope {}", streamName,
-						scopeName);
-				completeOperation((O) streamOp, RESP_FAIL_UNKNOWN);
+					"Failed to seal the stream {} in the scope {}", streamName, scopeName
+				);
 			}
+			val deleteStreamFuture = controller.deleteStream(scopeName,streamName);
+			deleteStreamFuture.handle((returned, thrown) ->
+					completeStreamDeleteOperation(streamOp, returned, thrown, scopeName, streamName)
+			);
 		} catch(final NullPointerException e) {
 			if(!isStarted()) {
 				completeOperation((O) streamOp, INTERRUPTED);


### PR DESCRIPTION
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.

Signed-off-by: Igor <hokletka@gmail.com>

  Make create and delete stream operations asynchronous with CompleatableFuture.handle().
  Now we try to delete the stream whether it is sealed or not
  Add two methods to complete create or delete operation for stream.