### PR TITLE
[PRAVEGA-89] Release version with Mongoose base 4.2.12.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ repositories {
 }
 description = "Mongoose is a high-load storage performance testing tool"
 group = "com.github.emc-mongoose"
-version = "4.2.15"
+version = "4.2.16"
 sourceCompatibility = 11
 targetCompatibility = 11
 ext {
@@ -42,7 +42,7 @@ ext {
 		grpc                     : "1.17.1",
 		guava                    : "27.0.1-jre",
 		log4j                    : "2.8.2",
-		mongooseBase             : "4.2.11",
+		mongooseBase             : "4.2.12",
 		mongooseStorageDriverPreempt: "4.2.14",
 		mongooseLoadStepPipeline : "4.2.9",
 		netty                    : "4.1.16.Final",


### PR DESCRIPTION
**Now**: the project uses Mongoose-Base 4.2.11 as a dependency.
**Then**: it should use Mongoose-Base 4.2.12

Related JIRA's task: https://mongoose-issues.atlassian.net/browse/PRAVEGA-89