### PR TITLE
Add storage-net-maxConnPerSegmentstore parameter

### DIFF
--- a/src/main/java/com/emc/mongoose/storage/driver/pravega/PravegaStorageDriver.java
+++ b/src/main/java/com/emc/mongoose/storage/driver/pravega/PravegaStorageDriver.java
@@ -114,6 +114,7 @@ public class PravegaStorageDriver<I extends DataItem, O extends DataOperation<I>
 	protected final String scopeName;
 	protected final String[] endpointAddrs;
 	protected final int nodePort;
+	protected final int maxConnectionsPerSegmentstore;
 	protected final long controlApiTimeoutMillis;
 	protected final boolean transactionMode;
 	protected final long evtOpTimeoutMillis;
@@ -315,6 +316,7 @@ public class PravegaStorageDriver<I extends DataItem, O extends DataOperation<I>
 		val netConfig = storageConfig.configVal("net");
 		this.uriSchema = netConfig.stringVal("uri-schema");
 		this.scopeName = storageConfig.stringVal("namespace");
+		this.maxConnectionsPerSegmentstore = netConfig.intVal("maxConnPerSegmentstore");
 		if (scopeName == null || scopeName.isEmpty()) {
 			Loggers.ERR.warn("Scope name not set, use the \"storage-namespace\" configuration option");
 		}
@@ -378,7 +380,7 @@ public class PravegaStorageDriver<I extends DataItem, O extends DataOperation<I>
 	}
 
 	ClientConfig createClientConfig(final URI endpointUri) {
-		val maxConnPerSegStore = ioWorkerCount;
+		val maxConnPerSegStore = maxConnectionsPerSegmentstore;
 		val clientConfigBuilder = ClientConfig
 			.builder()
 			.controllerURI(endpointUri)

--- a/src/main/resources/config-schema-storage-pravega.yaml
+++ b/src/main/resources/config-schema-storage-pravega.yaml
@@ -23,6 +23,7 @@ storage:
     interestOpQueued: boolean
     keepAlive: boolean
     linger: int
+    maxConnPerSegmentstore: int
     reuseAddr: boolean
     rcvBuf: int
     sndBuf: int

--- a/src/main/resources/config/defaults-storage-driver-pravega.yaml
+++ b/src/main/resources/config/defaults-storage-driver-pravega.yaml
@@ -23,6 +23,7 @@ storage:
     interestOpQueued: false
     keepAlive: true
     linger: 0
+    maxConnPerSegmentstore: 5
     reuseAddr: true
     rcvBuf: 0
     sndBuf: 0

--- a/src/test/java/com/emc/mongoose/storage/driver/pravega/integration/CommonTest.java
+++ b/src/test/java/com/emc/mongoose/storage/driver/pravega/integration/CommonTest.java
@@ -68,14 +68,17 @@ public class CommonTest {
 			config.val("storage-net-tcpNoDelay", false);
 			config.val("storage-net-interestOpQueued", false);
 			config.val("storage-net-linger", 0);
+			config.val("storage-net-maxConnPerSegmentstore", 5);
 			config.val("storage-net-timeoutMillis", 0);
 			config.val("storage-net-node-addrs", PravegaNode.addr());
 			config.val("storage-net-node-port", PravegaNode.PORT);
 			config.val("storage-net-node-connAttemptsLimit", 0);
 			config.val("storage-net-uri-schema", "tcp");
+
 			config.val("storage-auth-uid", CREDENTIAL.getUid());
 			config.val("storage-auth-token", null);
 			config.val("storage-auth-secret", CREDENTIAL.getSecret());
+
 			config.val("storage-driver-control-scope", true);
 			config.val("storage-driver-control-timeoutMillis", 10_000);
 			config.val("storage-driver-event-transaction", false);

--- a/src/test/java/com/emc/mongoose/storage/driver/pravega/integration/DataOperationsTest.java
+++ b/src/test/java/com/emc/mongoose/storage/driver/pravega/integration/DataOperationsTest.java
@@ -82,7 +82,8 @@ public class DataOperationsTest extends PravegaStorageDriver<DataItem, DataOpera
 			config.val("storage-net-node-addrs", PravegaNode.addr());
 			config.val("storage-net-node-port", PravegaNode.PORT);
 			config.val("storage-net-node-connAttemptsLimit", 0);
-
+			config.val("storage-net-maxConnPerSegmentstore", 5);
+			
 			config.val("storage-auth-uid", null);
 			config.val("storage-auth-token", null);
 			config.val("storage-auth-secret", null);


### PR DESCRIPTION
Add new storage-net-maxConnPerSegmentstore parameter to have control over amount of the maximum opened connections to a single segmentstore.
Default value is taken from Pravega's class ClientConfig and equals 5.