### PR TITLE
Add new parameter to config to control creation of streams

### DIFF
--- a/src/main/resources/config-schema-storage-pravega.yaml
+++ b/src/main/resources/config-schema-storage-pravega.yaml
@@ -3,6 +3,7 @@ storage:
   driver:
     control:
       scope: boolean
+      stream: boolean
       timeoutMillis: long
     event:
       transaction: boolean

--- a/src/main/resources/config/defaults-storage-driver-pravega.yaml
+++ b/src/main/resources/config/defaults-storage-driver-pravega.yaml
@@ -3,6 +3,7 @@ storage:
   driver:
     control:
       scope: true
+      stream: true
       timeoutMillis: 10000
     event:
       transaction: false

--- a/src/test/java/com/emc/mongoose/storage/driver/pravega/integration/CommonTest.java
+++ b/src/test/java/com/emc/mongoose/storage/driver/pravega/integration/CommonTest.java
@@ -77,6 +77,7 @@ public class CommonTest {
 			config.val("storage-auth-token", null);
 			config.val("storage-auth-secret", CREDENTIAL.getSecret());
 			config.val("storage-driver-control-scope", true);
+			config.val("storage-driver-control-stream", true);
 			config.val("storage-driver-control-timeoutMillis", 10_000);
 			config.val("storage-driver-event-transaction", false);
 			config.val("storage-driver-event-key-enabled", true);

--- a/src/test/java/com/emc/mongoose/storage/driver/pravega/integration/DataOperationsTest.java
+++ b/src/test/java/com/emc/mongoose/storage/driver/pravega/integration/DataOperationsTest.java
@@ -88,6 +88,7 @@ public class DataOperationsTest extends PravegaStorageDriver<DataItem, DataOpera
 			config.val("storage-auth-secret", null);
 
 			config.val("storage-driver-control-scope", true);
+			config.val("storage-driver-control-stream", true);
 			config.val("storage-driver-control-timeoutMillis", 10_000);
 			config.val("storage-driver-event-transaction", false);
 			config.val("storage-driver-event-key-enabled", true);


### PR DESCRIPTION
Add new parameter to config to control creation of streams. If the flag is set to false, Mongoose will assume that the stream was pre-created.