### PR TITLE
Create a batch of new items instead of 1 item for higher throughput

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,9 +258,10 @@ To achieve maximum efficiency the main point to be considered is `auto-scaling`.
 threads is amount of segments in the stream, which is constant during the reading. With auto-scaling enabled, it is yet 
 to be found out what the best match is.
 
-Another important thing to notice is that there is always a single failed event in the metrics. This isn't a corrupted 
-event but a nuisance caused by the fact that we don't know the amount of events in the stream. So, unless you actually see
-log messages about corrupted events - never mind the single failed event.
+There are two ways reading can be done:
+
+ - Set the count/time limit to stop reading after a certain moment
+ - Don't specify any options to stop reading, in this case driver works endlessly unless explicitly stopped (e.g. ctrl+c)
 
 ### 5.1.3. Update
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ repositories {
 }
 description = "Mongoose is a high-load storage performance testing tool"
 group = "com.github.emc-mongoose"
-version = "4.2.27"
+version = "4.2.28"
 sourceCompatibility = 11
 targetCompatibility = 11
 ext {
@@ -59,8 +59,8 @@ ext {
 		log4j                    : "2.8.2",
 		mongooseBase             : "4.2.18",
 		mongooseStorageDriverPreempt: "4.2.23",
-		netty                    : "4.1.16.Final",
-		nettyTcNative            : "2.0.17.Final",
+		netty                    : "4.1.45.Final",
+		nettyTcNative            : "2.0.25.Final",
 		protobuf                 : "3.5.1",
 		scala                    : "2.12.6",
 	]

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -53,8 +53,8 @@ build:
   stage: build
   script:
     - ./gradlew clean jar
-#  tags:
-#    - pravega
+  tags:
+    - pravega
   artifacts:
     paths:
       - build/libs/mongoose-*.jar
@@ -63,8 +63,8 @@ test_unit:
   stage: test
   script:
     - ./gradlew clean test
-#  tags:
-#    - pravega
+  tags:
+    - pravega
   artifacts:
     paths:
       - build/reports/tests/test/*
@@ -77,8 +77,8 @@ test_integration:
     - nohup build/pravega_/bin/pravega-standalone 1,2 > build/pravega_nohup.out &
     - sleep 15
     - ./gradlew integrationTest
-#  tags:
-#    - pravega
+  tags:
+    - pravega
   after_script:
     - killall java
   artifacts:
@@ -122,8 +122,8 @@ build_docker_image:
     - sleep 15
     # Run the tests
     - robot --outputdir build/robotest --suite ${SUITE} --include ${TEST} src/test/robot
-#  tags:
-#    - pravega
+  tags:
+    - pravega
   after_script:
     - killall java
     - rebot build/robotest/output.xml
@@ -172,8 +172,8 @@ release_to_maven_repo:
     - if [ ! -z "$GPG_SECRING" ]; then echo $GPG_SECRING | base64 -d > /tmp/.gnupg/secring.gpg; fi
     - ./gradlew clean jar
     - ./gradlew -Psigning.keyId=${SIGNING_KEY_ID} -Psigning.password=${SIGNING_PASSWORD} -Psigning.secretKeyRingFile=/tmp/.gnupg/secring.gpg -PossrhUsername=${OSSRH_USERNAME} -PossrhPassword=${OSSRH_PASSWORD} publishToNexus closeAndReleaseRepository
-#  tags:
-#    - pravega
+  tags:
+    - pravega
   only:
     - latest
   except:
@@ -181,8 +181,8 @@ release_to_maven_repo:
 
 release_to_docker_hub:
   stage: deploy
-#  tags:
-#    - pravega
+  tags:
+    - pravega
   script:
     - docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
     - docker load < ${IMAGE_FILE_NAME}

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -53,8 +53,8 @@ build:
   stage: build
   script:
     - ./gradlew clean jar
-  tags:
-    - pravega
+#  tags:
+#    - pravega
   artifacts:
     paths:
       - build/libs/mongoose-*.jar
@@ -63,8 +63,8 @@ test_unit:
   stage: test
   script:
     - ./gradlew clean test
-  tags:
-    - pravega
+#  tags:
+#    - pravega
   artifacts:
     paths:
       - build/reports/tests/test/*
@@ -77,8 +77,8 @@ test_integration:
     - nohup build/pravega_/bin/pravega-standalone 1,2 > build/pravega_nohup.out &
     - sleep 15
     - ./gradlew integrationTest
-  tags:
-    - pravega
+#  tags:
+#    - pravega
   after_script:
     - killall java
   artifacts:
@@ -122,8 +122,8 @@ build_docker_image:
     - sleep 15
     # Run the tests
     - robot --outputdir build/robotest --suite ${SUITE} --include ${TEST} src/test/robot
-  tags:
-    - pravega
+#  tags:
+#    - pravega
   after_script:
     - killall java
     - rebot build/robotest/output.xml
@@ -172,8 +172,8 @@ release_to_maven_repo:
     - if [ ! -z "$GPG_SECRING" ]; then echo $GPG_SECRING | base64 -d > /tmp/.gnupg/secring.gpg; fi
     - ./gradlew clean jar
     - ./gradlew -Psigning.keyId=${SIGNING_KEY_ID} -Psigning.password=${SIGNING_PASSWORD} -Psigning.secretKeyRingFile=/tmp/.gnupg/secring.gpg -PossrhUsername=${OSSRH_USERNAME} -PossrhPassword=${OSSRH_PASSWORD} publishToNexus closeAndReleaseRepository
-  tags:
-    - pravega
+#  tags:
+#    - pravega
   only:
     - latest
   except:
@@ -181,8 +181,8 @@ release_to_maven_repo:
 
 release_to_docker_hub:
   stage: deploy
-  tags:
-    - pravega
+#  tags:
+#    - pravega
   script:
     - docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
     - docker load < ${IMAGE_FILE_NAME}

--- a/src/main/java/com/emc/mongoose/storage/driver/pravega/PravegaStorageDriver.java
+++ b/src/main/java/com/emc/mongoose/storage/driver/pravega/PravegaStorageDriver.java
@@ -873,7 +873,7 @@ public class PravegaStorageDriver<I extends DataItem, O extends DataOperation<I>
 				val evtReader = evtReader_;
 				for(var i = 0; i < opsCount; i ++) {
 					readEvent(readerGroupManager, evtReaderGroupName, evtReader, evtOps.get(i));
-					//in multistream case readerGroup and associated reader might be different for each op
+					// in multistream case readerGroup and associated reader might be different for each op
 				}
 				evtReaderPool.offer(evtReader);
 			} catch(final Throwable e) {
@@ -903,11 +903,11 @@ public class PravegaStorageDriver<I extends DataItem, O extends DataOperation<I>
 		if (null == evtData) {
 			val streamPos = evtRead.getPosition();
 			if (((PositionImpl)streamPos).getOwnedSegments().isEmpty()) {
-				//means that reader doesn't own any segments, so it can't read anything
+				// means that reader doesn't own any segments, so it can't read anything
 				Loggers.MSG.debug("{}: empty reader. No EventSegmentReader assigned", stepId);
 			}
-			//received an empty answer, so don't count the operation anywhere and just do the recycling
-			completeOperation(evtOp,PENDING);
+			// received an empty answer, so don't count the operation anywhere and just do the recycling
+			completeOperation(evtOp, PENDING);
 			} else {
 				val bytesDone = evtData.remaining();
 				val evtItem = evtOp.item();

--- a/src/main/java/com/emc/mongoose/storage/driver/pravega/PravegaStorageDriver.java
+++ b/src/main/java/com/emc/mongoose/storage/driver/pravega/PravegaStorageDriver.java
@@ -87,6 +87,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadFactory;
@@ -135,7 +136,7 @@ public class PravegaStorageDriver<I extends DataItem, O extends DataOperation<I>
 	private final Credentials cred;
 
 	Queue<EventStreamReader<ByteBuffer>> createEventStreamReaderPool(final String unused) {
-		return new ArrayBlockingQueue<>(ioWorkerCount);
+		return new LinkedBlockingQueue<>(ioWorkerCount);
 	}
 
 	@Value
@@ -453,8 +454,9 @@ public class PravegaStorageDriver<I extends DataItem, O extends DataOperation<I>
 		if (BYTES.equals(streamDataType)) {
 			items = listStreams(itemFactory, path, prefix, idRadix, lastPrevItem, count);
 		} else {
-			items = makeEventItems(itemFactory, path, prefix, lastPrevItem, 1);
-			//as we don't know how many items in the stream, we allocate memory for 1 item
+			items = makeEventItems(itemFactory, path, prefix, lastPrevItem, count);
+			// as we don't know how many items in the stream, we allocate memory for 1 batch of ops,
+			// set pending status for op if we know that it neither failed nor succeeded and then recycle it
 		}
 		return items;
 	}
@@ -866,6 +868,7 @@ public class PravegaStorageDriver<I extends DataItem, O extends DataOperation<I>
 				var evtReader_ = evtReaderPool.poll();
 				if(null == evtReader_) {
 					evtReader_ = clientFactory.createReader("reader-" + (System.nanoTime()), evtReaderGroupName, evtDeserializer, evtReaderConfig);
+					Loggers.MSG.info("{}: created a new reader in {} {}", stepId, Thread.currentThread().getName(), evtReader_.toString());
 				}
 				val evtReader = evtReader_;
 				for(var i = 0; i < opsCount; i ++) {
@@ -902,18 +905,9 @@ public class PravegaStorageDriver<I extends DataItem, O extends DataOperation<I>
 			if (((PositionImpl)streamPos).getOwnedSegments().isEmpty()) {
 				//means that reader doesn't own any segments, so it can't read anything
 				Loggers.MSG.debug("{}: empty reader. No EventSegmentReader assigned", stepId);
-				completeOperation(evtOp,PENDING);
-			} else {
-				val leftBytesForReaderGroup = ((ReaderGroupImpl)(readerGroupManager.getReaderGroup(evtReaderGroupName))).unreadBytes();
-				if (leftBytesForReaderGroup == 0) {
-					//end of all segments. unreadBytes() has a 20-30 sec delay.
-					completeOperation(evtOp,FAIL_TIMEOUT);
-					Loggers.MSG.info("{}: no more events for RG {}", stepId, evtReaderGroupName);
-				} else {
-					//end of one of the segments
-					completeOperation(evtOp,PENDING);
-				}
 			}
+			//received an empty answer, so don't count the operation anywhere and just do the recycling
+			completeOperation(evtOp,PENDING);
 			} else {
 				val bytesDone = evtData.remaining();
 				val evtItem = evtOp.item();


### PR DESCRIPTION
Change the working mode from "end when it seems to be nothing left in the stream" to "hang and wait when there is nothing left"
Change ArrayBlockingQueue to LinkedBlockingQueue to reduce thread blocking time on offer and poll operations
Earlier creating a batch of items was a bad solution as it would be reflected in the overall statistics table. With the new "hang and wait" mode it's not the case.