### PR TITLE
[PRAVEGA-103] Update references to "Credentials" interface.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ ext {
 		grpc                     : "1.30.0",
 		guava                    : "28.1-jre",
 		log4j                    : "2.8.2",
-		mongooseBase             : "4.2.19",
+		mongooseBase             : "4.3.0",
 		mongooseStorageDriverPreempt: "4.2.23",
 		netty                    : "4.1.45.Final",
 		nettyTcNative            : "2.0.25.Final",

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ task clonePravegaRepo {
 		}
 		if(!destDir.exists()) {
 			def gitRepo = Grgit.clone {
-				uri = "https://github.com/pravega/pravega.git"
+				uri = pravegaUri
 				dir = pravegaSrcDir
 			}
 			gitRepo.reset {

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ ext {
 		grpc                     : "1.30.0",
 		guava                    : "28.1-jre",
 		log4j                    : "2.8.2",
-		mongooseBase             : "4.3.0",
+		mongooseBase             : "4.3.0-development",
 		mongooseStorageDriverPreempt: "4.2.23",
 		netty                    : "4.1.45.Final",
 		nettyTcNative            : "2.0.25.Final",

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ ext {
 		grpc                     : "1.30.0",
 		guava                    : "28.1-jre",
 		log4j                    : "2.8.2",
-		mongooseBase             : "4.3.0-development",
+		mongooseBase             : "4.2.19",
 		mongooseStorageDriverPreempt: "4.2.23",
 		netty                    : "4.1.45.Final",
 		nettyTcNative            : "2.0.25.Final",

--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,7 @@ ext {
 	pravegaClientJarDir = "${pravegaSrcDir}${File.separator}client${File.separator}${buildLibsPath}"
 	pravegaCommonJarDir = "${pravegaSrcDir}${File.separator}common${File.separator}${buildLibsPath}"
 	pravegaSharedAuthpluginJarDir = "${pravegaSrcDir}${File.separator}shared${File.separator}authplugin${File.separator}${buildLibsPath}"
+	pravegaSharedSecurityPluginJarDir = "${pravegaSrcDir}${File.separator}shared${File.separator}security${File.separator}${buildLibsPath}"
 	pravegaSharedControllerApiJarDir = "${pravegaSrcDir}${File.separator}shared${File.separator}controller-api${File.separator}${buildLibsPath}"
 	pravegaSharedProtocolJarDir = "${pravegaSrcDir}${File.separator}shared${File.separator}protocol${File.separator}${buildLibsPath}"
 }
@@ -166,6 +167,7 @@ dependencies {
 		files(
 			"${pravegaClientJarDir}${File.separator}pravega-client-${pravegaVersion}.jar",
 			"${pravegaCommonJarDir}${File.separator}pravega-common-${pravegaVersion}.jar",
+				"${pravegaSharedSecurityPluginJarDir}${File.separator}pravega-shared-security-${pravegaVersion}.jar",
 			"${pravegaSharedAuthpluginJarDir}${File.separator}pravega-shared-authplugin-${pravegaVersion}.jar",
 			"${pravegaSharedControllerApiJarDir}${File.separator}pravega-shared-controller-api-${pravegaVersion}.jar",
 			"${pravegaSharedProtocolJarDir}${File.separator}pravega-shared-protocol-${pravegaVersion}.jar",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 pravegaCommit=cb8aab2
 pravegaVersion=v0.10.0
+pravegaUri=https://github.com/pravega/pravega.git

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-pravegaCommit=e4c436b
-pravegaVersion=v0.8.0
+pravegaCommit=cb8aab2
+pravegaVersion=v0.10.0

--- a/src/main/java/com/emc/mongoose/storage/driver/pravega/PravegaStorageDriver.java
+++ b/src/main/java/com/emc/mongoose/storage/driver/pravega/PravegaStorageDriver.java
@@ -96,8 +96,8 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import io.pravega.client.stream.impl.Credentials;
-import io.pravega.client.stream.impl.DefaultCredentials;
+import io.pravega.shared.security.auth.Credentials;
+import io.pravega.shared.security.auth.DefaultCredentials;
 import io.pravega.client.stream.impl.PositionImpl;
 import io.pravega.client.stream.impl.StreamImpl;
 import io.pravega.common.util.AsyncIterator;


### PR DESCRIPTION
**Description**

In Pravega r0.9, there were updates related to some security classes, including _**Credentials**_. Specifically, it has been moved onto a new package, `io.pravega.client.stream.impl`.
As for now, Pravega driver couldn’t be built with Pravega 0.10 development client libraries due to Credentials classes incompatibilities. 
See Pravega’s GitHub issues: #5339, #5436 and #5373.

Jira: https://mongoose-issues.atlassian.net/browse/PRAVEGA-103