### PR TITLE
[PRAVEGA-104] Add configurable Pravega URI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ ext {
 		grpc                     : "1.30.0",
 		guava                    : "28.1-jre",
 		log4j                    : "2.8.2",
-		mongooseBase             : "4.2.19",
+		mongooseBase             : "4.3.0",
 		mongooseStorageDriverPreempt: "4.2.23",
 		netty                    : "4.1.45.Final",
 		nettyTcNative            : "2.0.25.Final",

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ task clonePravegaRepo {
 		}
 		if(!destDir.exists()) {
 			def gitRepo = Grgit.clone {
-				uri = "https://github.com/pravega/pravega.git"
+				uri = pravegaUri
 				dir = pravegaSrcDir
 			}
 			gitRepo.reset {

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ ext {
 		grpc                     : "1.30.0",
 		guava                    : "28.1-jre",
 		log4j                    : "2.8.2",
-		mongooseBase             : "4.3.0",
+		mongooseBase             : "4.3.0-development",
 		mongooseStorageDriverPreempt: "4.2.23",
 		netty                    : "4.1.45.Final",
 		nettyTcNative            : "2.0.25.Final",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 pravegaCommit=cb8aab2
 pravegaVersion=v0.10.0
+pravegaUri=https://github.com/pravega/pravega.git


### PR DESCRIPTION
**Description**

Some users might have their own, forked version of Pravega. They wouldn't be able to build Mongoose Storage Driver Pravega with their own client libraries using the current implementation.
Adding a configurable Pravega URI would resolve the issue.

JIRA: https://mongoose-issues.atlassian.net/browse/PRAVEGA-104